### PR TITLE
Remove broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This repository contains the source code for the GitHub Android app.
   <img src="http://www.android.com/images/brand/android_app_on_play_large.png">
 </a>
 
-![](http://img.skitch.com/20120709-nkdc1yugu2qmdg1ss81m1gr9ty.jpg)
-
 Please see the [issues](https://github.com/github/android/issues) section to
 report any bugs or feature requests and to see the list of known issues.
 


### PR DESCRIPTION
The link http://img.skitch.com/20120709-nkdc1yugu2qmdg1ss81m1gr9ty.jpg in README.md is unable to access an image. It should be removed.
